### PR TITLE
Update terminal.js

### DIFF
--- a/src/terminal.js
+++ b/src/terminal.js
@@ -53,7 +53,7 @@ define(function (require, exports, module) {
             lineHeight,
             fontSize;
 
-        if (this.terminals[terminalId]) {
+        if (this.terminals && this.terminals[terminalId]) {
             height = $bashPanel.height();
             width = $bashPanel.width();
             height -= $bashPanel.find('.toolbar').height() + 10; //5px top/bottom border to remove


### PR DESCRIPTION
If the panel triggers 'resize' before a terminal panel was opened/created the this.terminals isn't defined and so the access to this.terminals[terminalId] forces in a crash.
