### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 Brackets Terminal
 =================
 
-#MAINTEINER NEEDED
+# MAINTEINER NEEDED
 I no longer use brackets as my day-to-day editor and  I'm not able to maintain this plugin anymore. I'll be happy to grant access to someone interest in doing so though - if you'd like to help, open an issue :)
 
 
@@ -14,7 +14,7 @@ You can also run another editor inside brackets!
 ![Nano](images/screenshot2.png)
 
 
-##Installation
+## Installation
 
 * Brackets-terminal requires a [`tty.js`](https://github.com/chjj/tty.js/) server under the hood: run `$ npm install -g tty.js`
 * Open a terminal and start the server with `$ tty.js`
@@ -22,7 +22,7 @@ You can also run another editor inside brackets!
 * Open Brackets > Extension Manager > Available and look for 'Brackets Terminal'. Hit `Install`
 * Note that `tty.js` runs on port `8080` by default. You can specify a different port by running it with `tty.js --port <another_number>` and then set the same port in View > Bracket terminal settings
 
-##Usage
+## Usage
 
 You will see a new button on the sidebar as well as a new command in the menu (`View > Show Terminal`) - and a `Cmd/Ctrl+shift+P` keyboard shortcut. If everything goes well,
 the button in the sidebar will turn green and a terminal will show up as a bottom panel.
@@ -30,18 +30,18 @@ Starting from version 0.3, brackets terminal support multiple tab, too!
 
 
 
-##Requirement
+## Requirement
 
 * \*nix environment (may work with Cygwin or similar, but not tested)
 * `node.js` and `npm` installed
 
 
-##Troubleshooting
+## Troubleshooting
 
 If, for some reason, your button turn yellow try to hit it back, it should go back to gray and another hit should open the terminal again.
 If, at startup, the button is light-gray or it becomes red - it's because the tty.js server is no longer running.
 
-##Contribution
+## Contribution
 
 Please, report any issue on the github repository, pull requests are welcome too.
 


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
